### PR TITLE
Fix z scale for overview, wood, round and metal scenes

### DIFF
--- a/Assets/Scenes/MetalTowerScene.unity
+++ b/Assets/Scenes/MetalTowerScene.unity
@@ -542,14 +542,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1609192433}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.0042549805, y: -0.6108931, z: 0.008754409, w: 0.79165334}
+  m_LocalRotation: {x: -0.00027921636, y: -0.882364, z: 0.009729674, w: 0.47046685}
   m_LocalPosition: {x: -102, y: -28, z: -139.7}
-  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: -2.8088877}
-  m_ConstrainProportionsScale: 1
+  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: 2.808888}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1389303313}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -180.227, y: 104.69, z: -178.908}
+  m_LocalEulerAnglesHint: {x: -180.969, y: 56.137, z: -179.447}
 --- !u!20 &1706374751 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 2473723092127856999, guid: a8ef121d7b4e94b47b865c1adbcce270, type: 3}

--- a/Assets/Scenes/OverviewScene.unity
+++ b/Assets/Scenes/OverviewScene.unity
@@ -189,7 +189,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.031226823
+      value: 0.04031695
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalScale.y
@@ -209,43 +209,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -58.62
+      value: -49.57
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.18088774
+      value: 0.20259465
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.034219507
+      value: -0.005589517
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.98077196
+      value: 0.97855514
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.06476889
+      value: -0.036796533
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -134.24
+      value: -114.76
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 3.43
+      value: 2.53
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 8.015
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -159.277
+      value: -203.446
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -2.529
+      value: -1.485
       objectReference: {fileID: 0}
     - target: {fileID: 3438094606004272257, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchorMax.y
@@ -447,8 +447,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0.6710941, y: -0.07792178, z: 0.73444134, w: -0.06447389}
   m_LocalPosition: {x: -123.9, y: -37.6, z: -39.1}
-  m_LocalScale: {x: 4.115305, y: 4.115305, z: -4.115305}
-  m_ConstrainProportionsScale: 1
+  m_LocalScale: {x: 4.115305, y: 4.115305, z: 4.115305}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1584203699}
   m_Father: {fileID: 0}
@@ -574,13 +574,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 514164237}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.08456587, y: -0, z: -0, w: 0.99641794}
-  m_LocalPosition: {x: -19.89, y: -16.87, z: -23.24}
+  m_LocalRotation: {x: 0.08354141, y: -0.1546276, z: -0.013123231, w: 0.9843469}
+  m_LocalPosition: {x: 44.699997, y: -18.200003, z: -15.6}
   m_LocalScale: {x: 12.212994, y: 4.4745207, z: 19.631119}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1677345093}
-  m_LocalEulerAnglesHint: {x: 9.702, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 9.231, y: -18.097, z: -3.001}
 --- !u!65 &514164239
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -847,7 +847,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 20.205
+      value: 17.69
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.w
@@ -867,11 +867,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -141.25
+      value: -121.81
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -34.29
+      value: -33.77
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1012,43 +1012,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -15.56
+      value: -10.85
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.6457312
+      value: -0.71200943
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.30947155
+      value: -0.27132043
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.6783851
+      value: -0.63652146
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.1644758
+      value: 0.11944972
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -150.18
+      value: -111.37
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -26.96
+      value: -23.84
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 38.523
+      value: 32.577
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -98.227
+      value: 87.112
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -15.378
+      value: 12.007
       objectReference: {fileID: 0}
     - target: {fileID: 3465452684883965436, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_Enabled
@@ -1492,13 +1492,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1638559686}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.08456587, y: -0, z: -0, w: 0.99641794}
-  m_LocalPosition: {x: 33.046265, y: 27.291832, z: -82.68574}
-  m_LocalScale: {x: 2.6399, y: 10.582817, z: 4.636761}
+  m_LocalRotation: {x: 0.08416718, y: -0.09664161, z: -0.008201964, w: 0.99172026}
+  m_LocalPosition: {x: 11.76, y: 28.61, z: -83.86}
+  m_LocalScale: {x: 2.6399, y: 12.226329, z: 4.636761}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1677345093}
-  m_LocalEulerAnglesHint: {x: 9.702, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 9.518, y: -11.289, z: -1.891}
 --- !u!1 &1655703221
 GameObject:
   m_ObjectHideFlags: 0
@@ -1597,13 +1597,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1655703221}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.08419229, y: -0.09355578, z: -0.007940069, w: 0.99201614}
-  m_LocalPosition: {x: 4.966263, y: 28.921833, z: -87.46574}
+  m_LocalRotation: {x: 0.08452964, y: -0.029164938, z: -0.002475224, w: 0.995991}
+  m_LocalPosition: {x: 39.86, y: 28.26, z: -83.55}
   m_LocalScale: {x: 2.6399, y: 10.582817, z: 4.6367607}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1677345093}
-  m_LocalEulerAnglesHint: {x: 9.529, y: -10.928, z: -1.831}
+  m_LocalEulerAnglesHint: {x: 9.685, y: -3.403, z: -0.573}
 --- !u!1 &1677345092
 GameObject:
   m_ObjectHideFlags: 0
@@ -1777,13 +1777,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1796034980}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.030099535, y: 0.61069465, z: -0.02323985, w: 0.7909527}
-  m_LocalPosition: {x: -3.33, y: -25.9, z: 29.25}
+  m_LocalRotation: {x: 0.03354803, y: 0.69444865, z: -0.02041153, w: 0.71847}
+  m_LocalPosition: {x: 23.339996, y: -27.959997, z: 33.78}
   m_LocalScale: {x: 5.304225, y: 1.943329, z: 8.525991}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1677345093}
-  m_LocalEulerAnglesHint: {x: 4.359, y: 75.343, z: 0}
+  m_LocalEulerAnglesHint: {x: 4.391, y: 88.09, z: 0.992}
 --- !u!65 &1796034982
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2050,7 +2050,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 20.205
+      value: 21.87
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.w
@@ -2070,11 +2070,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -125.07
+      value: -137.95
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -25.62
+      value: -25.97
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2224,8 +2224,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2113538662}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: 0.99876004, z: -0, w: 0.049783904}
-  m_LocalPosition: {x: -100.75591, y: -2.9549, z: -19.705465}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -167.3, y: -2.9549, z: -26.4}
   m_LocalScale: {x: 0.8499657, y: 15.766269, z: 29.519653}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2234,7 +2234,7 @@ Transform:
   - {fileID: 1808893159}
   - {fileID: 113443674}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 174.293, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!328 &2113538667
 VideoPlayer:
   m_ObjectHideFlags: 0
@@ -2372,7 +2372,7 @@ Transform:
   m_GameObject: {fileID: 2132332627}
   serializedVersion: 2
   m_LocalRotation: {x: 0.020152781, y: -0.0021103001, z: 0.008150859, w: 0.99976146}
-  m_LocalPosition: {x: 20.896263, y: -27.148169, z: 59.874268}
+  m_LocalPosition: {x: -5.2, y: -27.6, z: 59.8}
   m_LocalScale: {x: 13.09492, y: 1.8607788, z: 12.573257}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2621,7 +2621,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.03351998
+      value: 0.037227288
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalScale.y
@@ -2641,43 +2641,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -54.631
+      value: -51.07
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.05405615
+      value: 0.06052206
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.037666257
+      value: 0.026036406
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.993535
+      value: 0.9918486
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.09245257
+      value: 0.10906668
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -116.39
+      value: -130.45
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 2.2411
+      value: 2.11
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.381
+      value: -12.31
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -39.704
+      value: -187.394
       objectReference: {fileID: 0}
     - target: {fileID: 2516953403633641432, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 3.297
+      value: 3.806
       objectReference: {fileID: 0}
     - target: {fileID: 3438094606004272257, guid: 32413647f33e47c448f7876dcd2969d6, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scenes/RoundBuildingScene.unity
+++ b/Assets/Scenes/RoundBuildingScene.unity
@@ -566,14 +566,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1609192433}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.0061777458, y: -0.40961203, z: 0.0075219665, w: 0.9122079}
-  m_LocalPosition: {x: -75, y: -24.61, z: -46.45}
-  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: -2.8088877}
-  m_ConstrainProportionsScale: 1
+  m_LocalRotation: {x: 0.007221299, y: -0.93056387, z: 0.006526666, w: -0.36600032}
+  m_LocalPosition: {x: -107.6, y: -25.9, z: -108.2}
+  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: 2.808888}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1389303313}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -179.707, y: 131.634, z: -178.924}
+  m_LocalEulerAnglesHint: {x: -180.393, y: -42.944, z: -181.044}
 --- !u!1001 &1835211950
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/RoundBuildingScene.unity
+++ b/Assets/Scenes/RoundBuildingScene.unity
@@ -566,14 +566,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1609192433}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.007221299, y: -0.93056387, z: 0.006526666, w: -0.36600032}
-  m_LocalPosition: {x: -107.6, y: -25.9, z: -108.2}
+  m_LocalRotation: {x: 0.004399218, y: -0.9999222, z: 0.008682823, w: -0.0078036543}
+  m_LocalPosition: {x: -151.5, y: -26.5, z: -83}
   m_LocalScale: {x: 2.8088877, y: 2.8088877, z: 2.808888}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1389303313}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -180.393, y: -42.944, z: -181.044}
+  m_LocalEulerAnglesHint: {x: -180.991, y: -0.8989868, z: -180.512}
 --- !u!1001 &1835211950
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/WoodenBuildingScene.unity
+++ b/Assets/Scenes/WoodenBuildingScene.unity
@@ -901,14 +901,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1609192433}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.0075425473, y: -0.22124076, z: 0.006152602, w: 0.9751707}
-  m_LocalPosition: {x: -141.5, y: -19, z: -133.4}
-  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: -2.8088877}
-  m_ConstrainProportionsScale: 1
+  m_LocalRotation: {x: -0.000793509, y: -0.8562417, z: 0.009701283, w: 0.5164837}
+  m_LocalPosition: {x: -146.4, y: -19.4, z: -154.9}
+  m_LocalScale: {x: 2.8088877, y: 2.8088877, z: 2.808888}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1389303313}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -179.313, y: 154.43, z: -179.121}
+  m_LocalEulerAnglesHint: {x: -180.905, y: 62.202003, z: -179.348}
 --- !u!1001 &3736873320660072059
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The renderer looks mirrored due to the z scale factor being a negative number.
Fixing this broke the navigation, which I now fixed by hand.