### PR TITLE
Improve video player start and pause

### DIFF
--- a/Assets/Prefabs/PlayBox.prefab
+++ b/Assets/Prefabs/PlayBox.prefab
@@ -1,5 +1,88 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3929921702778762882
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6207003715387228949}
+  - component: {fileID: 5640830403395400688}
+  - component: {fileID: 6617161525161948701}
+  m_Layer: 0
+  m_Name: PlayBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6207003715387228949
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3929921702778762882}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9128542054408996523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5640830403395400688
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3929921702778762882}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6617161525161948701
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3929921702778762882}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 15bc84e27883d3a46b99e4f67210196f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &5931036583820307075
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,7 +115,8 @@ Transform:
   m_LocalPosition: {x: -2.95092, y: -0.544333, z: 0.28060746}
   m_LocalScale: {x: 1, y: 0.19878393, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6207003715387228949}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1051222951624127063
@@ -50,7 +134,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5931036583820307075}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -104,8 +188,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1.5338659, y: 17.791822, z: 1.4503138}
+  m_Center: {x: -0.04295993, y: 8.395911, z: -0.00054752827}
 --- !u!114 &1666966161011243925
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BTS/BtsScene.unity
+++ b/Assets/Scenes/BTS/BtsScene.unity
@@ -729,6 +729,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayBox (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 8441820017509349509, guid: 232116f2f5b12cf4ab9c951f47fa4757, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 9128542054408996523, guid: 232116f2f5b12cf4ab9c951f47fa4757, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.2519226
@@ -3671,6 +3675,10 @@ PrefabInstance:
     - target: {fileID: 5931036583820307075, guid: 232116f2f5b12cf4ab9c951f47fa4757, type: 3}
       propertyPath: m_Name
       value: PlayBox
+      objectReference: {fileID: 0}
+    - target: {fileID: 8441820017509349509, guid: 232116f2f5b12cf4ab9c951f47fa4757, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9128542054408996523, guid: 232116f2f5b12cf4ab9c951f47fa4757, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/PlayBox.cs
+++ b/Assets/Scripts/PlayBox.cs
@@ -7,24 +7,45 @@ public class PlayBox : MonoBehaviour
 {
     [SerializeField] 
     private VideoPlayer videoPlayer;
+    private GameObject head;
+    private Collider playBoxCollider;
 
-    private void OnTriggerEnter(Collider other)
+    void Start()
     {
-        if (videoPlayer == null)
+        if(videoPlayer == null)
         {
+            Debug.Log("No video player assigned, will ignore PlayBox");
             return;
         }
 
-        videoPlayer.Play();
+        head = GameObject.FindGameObjectWithTag("MainCamera");
+        playBoxCollider = GetComponent<Collider>();
+        StartCoroutine(CheckHeadPosition());
     }
 
-    private void OnTriggerExit(Collider other)
-    {
-        if (videoPlayer == null)
-        {
-            return;
-        }
 
-        videoPlayer.Stop();
+    IEnumerator CheckHeadPosition()
+    {
+        while (true)
+        {
+            yield return new WaitForSeconds(0.5f);
+            if (playBoxCollider.bounds.Contains(head.transform.position))
+            {
+                // Head is inside the collider
+                if (!videoPlayer.isPlaying)
+                {
+                    videoPlayer.Play();
+                }
+            }
+            else
+            {
+                // Head is outside the collider
+                if (videoPlayer.isPlaying)
+                {
+                    videoPlayer.Stop();
+                }
+            }
+        }
     }
 }
+


### PR DESCRIPTION
It now checks the head position instead of the character. This will allow the user to walk around and still activate the interview (even if they haven't teleported).
