### PR TITLE
Add floor tracking, precheck, location tracking and better reset

### DIFF
--- a/Assets/Prefabs/AirBalloon Simplified.prefab
+++ b/Assets/Prefabs/AirBalloon Simplified.prefab
@@ -1208,7 +1208,7 @@ Transform:
   m_GameObject: {fileID: 965474856788737997}
   serializedVersion: 2
   m_LocalRotation: {x: -0.0000000018626449, y: 0.05417826, z: 9.3132246e-10, w: 0.99853134}
-  m_LocalPosition: {x: 0.024, y: 0.22, z: -0.011}
+  m_LocalPosition: {x: 0, y: 0.438, z: 0}
   m_LocalScale: {x: 2, y: 2, z: 2}
   m_ConstrainProportionsScale: 1
   m_Children:
@@ -1343,6 +1343,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   xrOrigin: {fileID: 8372681589495884823}
   startPosition: {x: 0, y: 0, z: 0}
+  isHotAirBalloon: 1
 --- !u!1 &1156903040700415758
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/XR Origin (XR Rig) with Transitioner.prefab
+++ b/Assets/Prefabs/XR Origin (XR Rig) with Transitioner.prefab
@@ -193,6 +193,8 @@ GameObject:
   - component: {fileID: 2678965594983928872}
   - component: {fileID: 2521654943739253120}
   - component: {fileID: 5848647750349940330}
+  - component: {fileID: 7882269244780608696}
+  - component: {fileID: 1615142854669408642}
   m_Layer: 2
   m_Name: XR Origin (XR Rig) with Transitioner
   m_TagString: Untagged
@@ -232,7 +234,7 @@ MonoBehaviour:
   m_Camera: {fileID: 4354655868825582147}
   m_OriginBaseGameObject: {fileID: 3390369947204604588}
   m_CameraFloorOffsetObject: {fileID: 6234080260099021787}
-  m_RequestedTrackingOriginMode: 0
+  m_RequestedTrackingOriginMode: 2
   m_CameraYOffset: 0
 --- !u!143 &4169774746422887763
 CharacterController:
@@ -344,6 +346,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   xrOrigin: {fileID: 7563770604075223498}
   startPosition: {x: 0, y: 0, z: 0}
+  isHotAirBalloon: 1
+--- !u!33 &7882269244780608696
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390369947204604588}
+  m_Mesh: {fileID: -1120971793077124694, guid: 147ae308eec018b40a7b312ae58f44c7, type: 3}
+--- !u!23 &1615142854669408642
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390369947204604588}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 91ff3830fc4055a4fb0d0d2be32101a7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3835286287110683841
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BTS/BtsScene.unity
+++ b/Assets/Scenes/BTS/BtsScene.unity
@@ -566,7 +566,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4266640295717640281, guid: beb4e2871579447497fe41dfb108e2cd, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.0541942
+      value: 2.07194
       objectReference: {fileID: 0}
     - target: {fileID: 4266640295717640281, guid: beb4e2871579447497fe41dfb108e2cd, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1937,7 +1937,7 @@ Transform:
   m_GameObject: {fileID: 1259105905}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -116.287384, y: -2.0541942, z: -3.688795}
+  m_LocalPosition: {x: -116.287384, y: -1.989, z: -3.688795}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2210,7 +2210,7 @@ Transform:
   m_GameObject: {fileID: 1396155110}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -122.75, y: 0.24780583, z: -6.548}
+  m_LocalPosition: {x: -122.75, y: 0.288058, z: -6.548}
   m_LocalScale: {x: 5.503978, y: 0.22981, z: 6.131082}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2244,7 +2244,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1396155110}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -2257,7 +2257,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 842f1b88643f1bb458ba6243088e344e, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3595,6 +3595,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1615142854669408642, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3390369947204604588, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_Name
       value: XR Origin (XR Rig)
@@ -3617,7 +3621,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.36699998
+      value: 0.4905
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3654,6 +3658,10 @@ PrefabInstance:
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5848647750349940330, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: isHotAirBalloon
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/Immersive/ArenaScene.unity
+++ b/Assets/Scenes/Immersive/ArenaScene.unity
@@ -2521,6 +2521,10 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5848647750349940330, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: isHotAirBalloon
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7496634887004685646, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.185

--- a/Assets/Scenes/Immersive/OverviewScene.unity
+++ b/Assets/Scenes/Immersive/OverviewScene.unity
@@ -3350,6 +3350,61 @@ Transform:
   m_Children: []
   m_Father: {fileID: 128588301}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1646049259 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 965474856788737997, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
+  m_PrefabInstance: {fileID: 618306943086984903}
+  m_PrefabAsset: {fileID: 0}
+--- !u!33 &1646049267
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646049259}
+  m_Mesh: {fileID: -1120971793077124694, guid: 147ae308eec018b40a7b312ae58f44c7, type: 3}
+--- !u!23 &1646049268
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646049259}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 91ff3830fc4055a4fb0d0d2be32101a7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &1729362102
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3862,6 +3917,10 @@ PrefabInstance:
       propertyPath: Delay
       value: 30
       objectReference: {fileID: 0}
+    - target: {fileID: 2610947271399221566, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2694469041704701634, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: m_LocalScale.x
       value: 2
@@ -3873,18 +3932,6 @@ PrefabInstance:
     - target: {fileID: 2694469041704701634, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: m_LocalScale.z
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2694469041704701634, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2694469041704701634, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2694469041704701634, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2905404562485066807, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: m_Target
@@ -4053,7 +4100,13 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 8230439536493913885, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2022672158}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 965474856788737997, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1646049268}
+    - targetCorrespondingSourceObject: {fileID: 965474856788737997, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1646049267}
   m_SourcePrefab: {fileID: 100100000, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
 --- !u!4 &618306943086984904 stripped
 Transform:

--- a/Assets/Scenes/Immersive/StageScene.unity
+++ b/Assets/Scenes/Immersive/StageScene.unity
@@ -1714,7 +1714,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -10.509
+      value: -10.439
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1751,6 +1751,10 @@ PrefabInstance:
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5848647750349940330, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: isHotAirBalloon
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7563770604075223498, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_CameraYOffset

--- a/Assets/Scenes/Inspect/InspectScene.unity
+++ b/Assets/Scenes/Inspect/InspectScene.unity
@@ -646,6 +646,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5848647750349940330, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: isHotAirBalloon
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/OpeningScene.unity
+++ b/Assets/Scenes/OpeningScene.unity
@@ -2373,21 +2373,25 @@ PrefabInstance:
       propertyPath: resetTrackerOnLoad
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1615142854669408642, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3390369947204604588, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_Name
       value: XR Origin (XR Rig) with Transitioner
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2395,7 +2399,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.287
+      value: 0.225
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2433,9 +2437,17 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5848647750349940330, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: isHotAirBalloon
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7496634887004685646, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7563770604075223498, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
+      propertyPath: m_CameraYOffset
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/OpeningScene.unity
+++ b/Assets/Scenes/OpeningScene.unity
@@ -2383,15 +2383,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4487480933735331380, guid: 7cd23475eb6993841a2ad0b9f3b6432d, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/PrecheckScene.unity
+++ b/Assets/Scenes/PrecheckScene.unity
@@ -203,6 +203,7 @@ GameObject:
   - component: {fileID: 709522025}
   - component: {fileID: 709522024}
   - component: {fileID: 709522027}
+  - component: {fileID: 709522028}
   m_Layer: 0
   m_Name: XR Origin (VR)
   m_TagString: Untagged
@@ -270,6 +271,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   infoText: {fileID: 1344730241}
+--- !u!114 &709522028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709522023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d93c7fb7e42560c4093a88a9fdd735b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  xrOrigin: {fileID: 709522025}
+  startPosition: {x: 0, y: 0, z: 0}
+  isHotAirBalloon: 0
 --- !u!1 &1107680846
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PrecheckScene.unity
+++ b/Assets/Scenes/PrecheckScene.unity
@@ -1,0 +1,796 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &63996554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 63996557}
+  - component: {fileID: 63996556}
+  - component: {fileID: 63996555}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &63996555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63996554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &63996556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63996554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &63996557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63996554}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &709522023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 709522026}
+  - component: {fileID: 709522025}
+  - component: {fileID: 709522024}
+  - component: {fileID: 709522027}
+  m_Layer: 0
+  m_Name: XR Origin (VR)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &709522024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709522023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 017c5e3933235514c9520e1dace2a4b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ActionAssets:
+  - {fileID: -944628639613478452, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+--- !u!114 &709522025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709522023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0cb9aa70a22847b5925ee5f067c10a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Camera: {fileID: 1107680850}
+  m_OriginBaseGameObject: {fileID: 709522023}
+  m_CameraFloorOffsetObject: {fileID: 1374676388}
+  m_RequestedTrackingOriginMode: 0
+  m_CameraYOffset: 1.1176
+--- !u!4 &709522026
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709522023}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -517}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1374676389}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &709522027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709522023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b49269497d051248a28921c356219ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  infoText: {fileID: 1344730241}
+--- !u!1 &1107680846
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1107680847}
+  - component: {fileID: 1107680850}
+  - component: {fileID: 1107680849}
+  - component: {fileID: 1107680848}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1107680847
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1107680846}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1374676389}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1107680848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1107680846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2fadf230d1919748a9aa21d40f74619, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_IgnoreTrackingState: 0
+  m_PositionInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Position
+      m_Type: 0
+      m_ExpectedControlType: Vector3
+      m_Id: 0df3df57-dfcc-47e1-b496-35a6bf21813e
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: df9dcdc3-57d6-4496-afd1-90730500f67c
+        m_Path: <XRHMD>/centerEyePosition
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Position
+        m_Flags: 0
+      - m_Name: 
+        m_Id: 8398abfc-a2ed-4da1-94b3-268df7844da9
+        m_Path: <HandheldARInputDevice>/devicePosition
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Position
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_RotationInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Rotation
+      m_Type: 0
+      m_ExpectedControlType: Quaternion
+      m_Id: 88c9113b-50f8-4327-a79a-e769077fb57d
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: facefe75-a33f-4493-9a76-c598e478cd03
+        m_Path: <XRHMD>/centerEyeRotation
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Rotation
+        m_Flags: 0
+      - m_Name: 
+        m_Id: 47e0f2ad-b703-4ec0-8959-0a33020d89e9
+        m_Path: <HandheldARInputDevice>/deviceRotation
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Rotation
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_TrackingStateInput:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Tracking State
+      m_Type: 0
+      m_ExpectedControlType: Integer
+      m_Id: 161b772b-0883-4eda-b16f-fb602150ede6
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: c392dc3e-d455-4b79-abc0-1167f20a91d8
+        m_Path: <XRHMD>/trackingState
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Tracking State
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_PositionAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 3bc84356-21e5-43a1-b2f7-195bfbac0195
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+  m_RotationAction:
+    m_Name: 
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 4edf9516-4f3f-46fc-88e4-95eab09171ed
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings: []
+    m_Flags: 0
+--- !u!81 &1107680849
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1107680846}
+  m_Enabled: 1
+--- !u!20 &1107680850
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1107680846}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.01
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!1 &1344730239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1344730240}
+  - component: {fileID: 1344730242}
+  - component: {fileID: 1344730241}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1344730240
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1344730239}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2055222099}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1344730241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1344730239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: ...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -558.6528, y: 0, z: -557.2195, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1344730242
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1344730239}
+  m_CullTransparentMesh: 1
+--- !u!1 &1374676388
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1374676389}
+  m_Layer: 0
+  m_Name: Camera Offset
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1374676389
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1374676388}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.1176, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1107680847}
+  m_Father: {fileID: 709522026}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2055222095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2055222099}
+  - component: {fileID: 2055222098}
+  - component: {fileID: 2055222097}
+  - component: {fileID: 2055222096}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2055222096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055222095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &2055222097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055222095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!223 &2055222098
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055222095}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &2055222099
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2055222095}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1344730240}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1827, y: 824}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2143835457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2143835459}
+  - component: {fileID: 2143835458}
+  m_Layer: 0
+  m_Name: XR Interaction Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2143835458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2143835457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83e4e6cca11330d4088d729ab4fc9d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
+--- !u!4 &2143835459
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2143835457}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1547.5371, y: 779.84784, z: 1346.5669}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2055222099}
+  - {fileID: 63996557}
+  - {fileID: 2143835459}
+  - {fileID: 709522026}

--- a/Assets/Scenes/PrecheckScene.unity.meta
+++ b/Assets/Scenes/PrecheckScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90820da7e67f8584491a9915b3aa045f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BalloonSound.cs
+++ b/Assets/Scripts/BalloonSound.cs
@@ -28,14 +28,12 @@ public class Balloon : MonoBehaviour
         {
             if (currentTime - lastSoundTime >= soundCooldown)
             {
-                Debug.Log("+++MOVE SOUND: " + currentTime);
                 SoundManager.Instance.PlaySound(moveSound, childTransform);
                 lastSoundTime = currentTime;
             }
 
             if (HasDirectionChanged(currentPosition))
             {
-                Debug.Log("+++DIRECTION SOUND: " + currentTime);
                 SoundManager.Instance.PlaySound(directionChangeSound, childTransform);
                 lastSoundTime = currentTime;
             }

--- a/Assets/Scripts/BalloonTransporter.cs
+++ b/Assets/Scripts/BalloonTransporter.cs
@@ -18,7 +18,7 @@ public class BalloonTransporter : MonoBehaviour
 
     public string sceneName = "InspectScene";
     [SerializeField]
-    private int active = 0;
+    private static int active = 0;
 
     [SerializeField]
     private List<LocationInformation> locations;

--- a/Assets/Scripts/HomeTeleporter.cs
+++ b/Assets/Scripts/HomeTeleporter.cs
@@ -21,7 +21,6 @@ public class HomeTeleporter : MonoBehaviour
 
         var rightHandDevices = new List<UnityEngine.XR.InputDevice>();
         UnityEngine.XR.InputDevices.GetDevicesAtXRNode(UnityEngine.XR.XRNode.RightHand, rightHandDevices);
-        Debug.Log("HMM LOKING " + rightHandDevices.Count);
 
         if (rightHandDevices.Count == 1)
         {

--- a/Assets/Scripts/OneTimeTutorialDistanceBased.cs
+++ b/Assets/Scripts/OneTimeTutorialDistanceBased.cs
@@ -34,7 +34,10 @@ public class OneTimeTutorialDistanceBased : MonoBehaviour
             //TutorialCanvas.gameObject.transform.parent.gameObject.SetActive(false);
             try
             {
-                TutorialCanvas.GetComponent<SceneTutorial>().FinishTutorial();
+                if(TutorialCanvas != null)
+                {
+                    TutorialCanvas.GetComponent<SceneTutorial>().FinishTutorial();
+                }
             }catch (Exception ex)
             {
                 Time.timeScale = 1.0f;

--- a/Assets/Scripts/PreCheck.cs
+++ b/Assets/Scripts/PreCheck.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+
+public class PreCheck : MonoBehaviour
+{
+
+    [SerializeField]
+    private TextMeshProUGUI infoText;
+
+    void Start()
+    {
+        StartCoroutine(CheckHardwareReady());
+    }
+    private IEnumerator CheckHardwareReady()
+    {
+        yield return new WaitForEndOfFrame(); // wait one frame
+        if (ViewResetter.IsHardwarePresent())
+        {
+            UnityEngine.SceneManagement.SceneManager.LoadScene("OpeningScene");
+        }
+        else
+        {
+            infoText.SetText("Please start the application while wearing the headset!");
+        }
+    }
+}

--- a/Assets/Scripts/PreCheck.cs.meta
+++ b/Assets/Scripts/PreCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b49269497d051248a28921c356219ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SceneManager.cs
+++ b/Assets/Scripts/SceneManager.cs
@@ -13,13 +13,11 @@ public class SceneManager : MonoBehaviour
 
     void StartScene(Scene scene, LoadSceneMode m)
     {
-        Debug.Log("Reveal");
         EventManager.FireRevealEvent();
     }
 
     private void OnEnable()
     {
-        Debug.Log("On Enable Scene Manager");
         EventManager.SwitchScene += SwitchSceneHandler;
         UnityEngine.SceneManagement.SceneManager.sceneLoaded += StartScene;
     }
@@ -32,7 +30,6 @@ public class SceneManager : MonoBehaviour
 
     private void SwitchSceneHandler(string sceneName)
     {
-        Debug.Log("Should switch scenes now to " + sceneName);
         UnityEngine.SceneManagement.SceneManager.LoadScene(sceneName, LoadSceneMode.Single);
     }
 }

--- a/Assets/Scripts/SceneTutorial.cs
+++ b/Assets/Scripts/SceneTutorial.cs
@@ -43,7 +43,6 @@ public class SceneTutorial : MonoBehaviour
 
     public void ConfirmButtonPressed()
     {
-        Debug.Log("Confirm button pressed");
         FinishTutorial();
         SoundManager.Instance.PlaySound(buttonClickSound, transform);
     }

--- a/Assets/Scripts/ShowcaseTeleporter.cs
+++ b/Assets/Scripts/ShowcaseTeleporter.cs
@@ -39,7 +39,6 @@ public class ShowcaseTeleporter : MonoBehaviour
     private void OnHidden ()
     {
         EventManager.HideComplete -= OnHidden;
-        Debug.Log("OnHidden for " + sceneName);
         EventManager.FireSwitchSceneEvent(sceneName);
     }
 }

--- a/Assets/Scripts/TransitionManager.cs
+++ b/Assets/Scripts/TransitionManager.cs
@@ -40,7 +40,6 @@ public class TransitionManager : MonoBehaviour
     private void RevealPlayerHandler()
     {
         globals.Mode = Mode.NonInteractive;
-        Debug.Log("stargin reveal animation");
         if (SkipTransition)
         {
             StartCoroutine(PlayAnimation(1f, 1.1f));

--- a/Assets/Scripts/ViewResetter.cs
+++ b/Assets/Scripts/ViewResetter.cs
@@ -37,27 +37,9 @@ public class ViewResetter : MonoBehaviour
 
     void OnTrackingOriginUpdated(XRInputSubsystem subsystem)
     {
+        // We keep this for debugging purposes
         var current = subsystem.GetTrackingOriginMode();
         Debug.Log("CurrentMode: " + current);
-        Debug.Log("previousTrackingMode: " + previousTrackingMode);
-        Debug.Log("xrOrigin.CameraYOffset" + xrOrigin.CameraYOffset);
-        Debug.Log("xrOrigin.GetCameraFloorWorldPosition();" + xrOrigin.GetCameraFloorWorldPosition());
-
-
-        //xrOrigin.Camera.transform.localPosition = new Vector3(Camera.main.transform.localPosition.x, 0.2f, Camera.main.transform.localPosition.z);
-        if (previousTrackingMode == TrackingOriginModeFlags.Floor && current == TrackingOriginModeFlags.Floor && isInitialized)
-        {
-            // This must be a quest link triggered reset, because we switch between floor and device
-            // Your custom logic here
-            Debug.Log("N0 OnTrackingOriginUpdated: " + xrOrigin.transform.localPosition);
-            Debug.Log("N0 OnTrackingOriginUpdated: " + xrOrigin.transform.localScale);
-            // Debug.Log("N0 OnTrackingOriginUpdated: " + subsystem.);
-
-            Debug.Log("Tracking origin updated (recentered). " + xrOrigin.CurrentTrackingOriginMode);
-        }
-           //xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
-           // xrOrigin.MoveCameraToWorldLocation(new Vector3(startPosition.x, xrOrigin.Camera.transform.position.y, startPosition.z));
-        previousTrackingMode = current;
     }
 
     XRInputSubsystem GetXRInputSubsystem()
@@ -67,16 +49,9 @@ public class ViewResetter : MonoBehaviour
         return subsystems.FirstOrDefault();
     }
 
-
-    private void Awake()
-    {
-        Debug.Log("N0 wake: " + xrOrigin.transform.position);  
-    }
-
     void Start()
     {
         startPosition = xrOrigin.transform.position;
-        Debug.Log("N0 Start: " + xrOrigin.transform.position);
     }
 
     void Update()
@@ -140,7 +115,6 @@ public class ViewResetter : MonoBehaviour
 
     private IEnumerator InitializeCoroutine()
     {
-        Debug.Log("Reiniting floor mode");
         xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Device;
         yield return new WaitForSeconds(0.1f);
         xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
@@ -149,8 +123,6 @@ public class ViewResetter : MonoBehaviour
         {
             Vector3 parentPosition = transform.parent.position; // Assuming the moving object is the parent
             Vector3 targetPosition = new Vector3(parentPosition.x, xrOrigin.transform.position.y + xrOrigin.CameraInOriginSpaceHeight, parentPosition.z);
-            Debug.Log("Parent Position: " + parentPosition);
-            Debug.Log("Target Position: " + targetPosition);
             xrOrigin.MoveCameraToWorldLocation(targetPosition);
             xrOrigin.Camera.transform.localPosition = Vector3.zero; // Reset camera's local position
         }

--- a/Assets/Scripts/ViewResetter.cs
+++ b/Assets/Scripts/ViewResetter.cs
@@ -1,44 +1,114 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Unity.XR.CoreUtils;
 using UnityEngine;
 using UnityEngine.XR;
+using UnityEngine.XR.OpenXR;
+using UnityEngine.XR.Interaction.Toolkit.Utilities;
+using UnityEngine.SocialPlatforms;
 
 public class ViewResetter : MonoBehaviour
 {
     public XROrigin xrOrigin;
     public Vector3 startPosition;
+    public bool isHotAirBalloon = true;
+    private bool isInitialized;
+    private TrackingOriginModeFlags previousTrackingMode = TrackingOriginModeFlags.Unknown;
 
-    // Start is called before the first frame update
+    void OnEnable()
+    {
+        XRInputSubsystem subsystem = GetXRInputSubsystem();
+        if (subsystem != null)
+        {
+            subsystem.trackingOriginUpdated += OnTrackingOriginUpdated;
+        }
+        OpenXRSettings.SetAllowRecentering(true);
+    }
+
+    void OnDisable()
+    {
+        XRInputSubsystem subsystem = GetXRInputSubsystem();
+        if (subsystem != null)
+        {
+            subsystem.trackingOriginUpdated -= OnTrackingOriginUpdated;
+        }
+    }
+
+    void OnTrackingOriginUpdated(XRInputSubsystem subsystem)
+    {
+        var current = subsystem.GetTrackingOriginMode();
+        Debug.Log("CurrentMode: " + current);
+        Debug.Log("previousTrackingMode: " + previousTrackingMode);
+        Debug.Log("xrOrigin.CameraYOffset" + xrOrigin.CameraYOffset);
+        Debug.Log("xrOrigin.GetCameraFloorWorldPosition();" + xrOrigin.GetCameraFloorWorldPosition());
+
+
+        //xrOrigin.Camera.transform.localPosition = new Vector3(Camera.main.transform.localPosition.x, 0.2f, Camera.main.transform.localPosition.z);
+        if (previousTrackingMode == TrackingOriginModeFlags.Floor && current == TrackingOriginModeFlags.Floor && isInitialized)
+        {
+            // This must be a quest link triggered reset, because we switch between floor and device
+            // Your custom logic here
+            Debug.Log("N0 OnTrackingOriginUpdated: " + xrOrigin.transform.localPosition);
+            Debug.Log("N0 OnTrackingOriginUpdated: " + xrOrigin.transform.localScale);
+            // Debug.Log("N0 OnTrackingOriginUpdated: " + subsystem.);
+
+            Debug.Log("Tracking origin updated (recentered). " + xrOrigin.CurrentTrackingOriginMode);
+        }
+           //xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
+           // xrOrigin.MoveCameraToWorldLocation(new Vector3(startPosition.x, xrOrigin.Camera.transform.position.y, startPosition.z));
+        previousTrackingMode = current;
+    }
+
+    XRInputSubsystem GetXRInputSubsystem()
+    {
+        List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();
+        SubsystemManager.GetInstances(subsystems);
+        return subsystems.FirstOrDefault();
+    }
+
+
+    private void Awake()
+    {
+        Debug.Log("N0 wake: " + xrOrigin.transform.position);  
+    }
+
     void Start()
     {
-        //xrOrigin = FindAnyObjectByType<XROrigin>();
-        startPosition = xrOrigin.transform.localPosition;
+        startPosition = xrOrigin.transform.position;
+        Debug.Log("N0 Start: " + xrOrigin.transform.position);
     }
 
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.R)) // Change the key as needed 
+        if (!isInitialized && IsHardwarePresent())
+        {
+            isInitialized = true;
+            StartCoroutine(InitializeCoroutine());
+        }
+
+        if (Input.GetKeyDown(KeyCode.R)) 
         {
             Debug.Log("Resetting");
-            StartCoroutine(Reset());
+            isInitialized = false;
             ResetSubsystem();
-            /*
-            xrOrigin.transform.localPosition = startPosition;
-            InputTracking.Recenter();
-            */
 
         }
 
-        if (Input.GetKeyDown(KeyCode.N)) // Change the key as needed 
+        if (Input.GetKeyDown(KeyCode.N))
         {
             Debug.Log("Restarting");
+            var logger = FindAnyObjectByType<PlayerPositionLogger>();
+            if (logger != null)
+            {
+                logger.ExitLogging(true);
+            }
             System.Diagnostics.Process.Start(Application.dataPath.Replace("_Data", ".exe")); // Start a new instance of the application
             Application.Quit(); // Quit the current instance
         }
 
 
-        if (Input.GetKeyDown(KeyCode.X)) // Change the key as needed 
+        if (Input.GetKeyDown(KeyCode.X))
         {
             Debug.Log("Exiting");
             var logger = FindAnyObjectByType<PlayerPositionLogger>();
@@ -51,16 +121,56 @@ public class ViewResetter : MonoBehaviour
 
     }
 
-
-    void ResetSubsystem()
+    public static bool IsHardwarePresent()
     {
+        var xrDisplaySubsystems = new List<XRDisplaySubsystem>();
+        SubsystemManager.GetInstances<XRDisplaySubsystem>(xrDisplaySubsystems);
+
+        foreach (var xrDisplay in xrDisplaySubsystems)
+        {
+            if (xrDisplay.running)
+            {
+                Debug.Log("XR Display is Running");
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private IEnumerator InitializeCoroutine()
+    {
+        Debug.Log("Reiniting floor mode");
+        xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Device;
+        yield return new WaitForSeconds(0.1f);
+        xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
+
+        if (isHotAirBalloon)
+        {
+            Vector3 parentPosition = transform.parent.position; // Assuming the moving object is the parent
+            Vector3 targetPosition = new Vector3(parentPosition.x, xrOrigin.transform.position.y + xrOrigin.CameraInOriginSpaceHeight, parentPosition.z);
+            Debug.Log("Parent Position: " + parentPosition);
+            Debug.Log("Target Position: " + targetPosition);
+            xrOrigin.MoveCameraToWorldLocation(targetPosition);
+            xrOrigin.Camera.transform.localPosition = Vector3.zero; // Reset camera's local position
+        }
+        else
+        {
+           xrOrigin.MoveCameraToWorldLocation(new Vector3(startPosition.x, startPosition.y + xrOrigin.CameraInOriginSpaceHeight, startPosition.z));
+        }
+    }
+
+    private void ResetSubsystem()
+    { 
         var inputSubsystems = new List<XRInputSubsystem>();
         SubsystemManager.GetInstances(inputSubsystems);
         Debug.Log("Subsystems: " + inputSubsystems.Count);
 
         foreach (var subsystem in inputSubsystems)
         {
-            Debug.Log(subsystem.ToString());
+            subsystem.Stop();
+            subsystem.Start();
+
             if (subsystem.TryRecenter())
             {
                 Debug.Log("View recentered successfully.");
@@ -70,15 +180,7 @@ public class ViewResetter : MonoBehaviour
                 Debug.LogWarning("Failed to recenter view.");
             }
         }
-    }
 
-    IEnumerator Reset()
-    {
-        xrOrigin.transform.localPosition = startPosition;
-        yield return new WaitForSeconds(0.05f);
-        xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
-        yield return new WaitForSeconds(0.1f);
-        xrOrigin.RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Device;
     }
 }
 

--- a/Assets/Textures/icons.meta
+++ b/Assets/Textures/icons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9c388bbf3924884692bc197db1595b5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Textures/icons/planica_icon.png
+++ b/Assets/Textures/icons/planica_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deef4330062f791fbae55322c2301b870a977cd910710b354aa2c0b7d34ebff6
+size 222011

--- a/Assets/Textures/icons/planica_icon.png.meta
+++ b/Assets/Textures/icons/planica_icon.png.meta
@@ -1,0 +1,166 @@
+fileFormatVersion: 2
+guid: 73577418594c94341853f4a93495f37f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -508,7 +508,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5019471fb2174e5c852ecd4047163007, type: 3}
   m_Name: HandInteractionProfile Standalone
   m_EditorClassIdentifier: 
-  m_enabled: 1
+  m_enabled: 0
   nameUi: Hand Interaction Profile
   version: 0.0.1
   featureIdInternal: com.unity.openxr.feature.input.handinteraction

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/PrecheckScene.unity
+    guid: 90820da7e67f8584491a9915b3aa045f
+  - enabled: 1
     path: Assets/Scenes/OpeningScene.unity
     guid: 35d9f7dcbfa2b0e45855f432cbfb0162
   - enabled: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -135,7 +135,7 @@ PlayerSettings:
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
-  bundleVersion: 0.1
+  bundleVersion: 1.1
   preloadedAssets:
   - {fileID: 4206469802684931788, guid: 9cc3e92e5687f044296bfd737f2eee02, type: 2}
   - {fileID: 11400000, guid: 6cdf0e63ed2b03b4cbd84eef2976bb5b, type: 2}
@@ -159,7 +159,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Standalone: com.HSLU.Planica-VR
+    Standalone: com.HSLU.PlanicaVR
   buildNumber:
     Bratwurst: 0
     Standalone: 0
@@ -281,7 +281,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 73577418594c94341853f4a93495f37f, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,10 +136,7 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 1.1
-  preloadedAssets:
-  - {fileID: 4206469802684931788, guid: 9cc3e92e5687f044296bfd737f2eee02, type: 2}
-  - {fileID: 11400000, guid: 6cdf0e63ed2b03b4cbd84eef2976bb5b, type: 2}
-  - {fileID: 7947974280430748581, guid: 7d659987485a58941b2268cc733c8d05, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,10 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 1.1
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 4206469802684931788, guid: 9cc3e92e5687f044296bfd737f2eee02, type: 2}
+  - {fileID: 11400000, guid: 6cdf0e63ed2b03b4cbd84eef2976bb5b, type: 2}
+  - {fileID: 7947974280430748581, guid: 7d659987485a58941b2268cc733c8d05, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Here are all the detailed improvements/fixes:

Shortcuts
- Improved the R button, it no longer uses the subsystem (which didn't work) but instead has custom calculations for resetting. This should fully replace the "Reset View" button from Meta Link (which broke the application).

Logging
- Log files are now saved in the same directory as the .exe file.

Navigation
- The hot air balloon now remembers its previous location and automatically displays the next location upon interaction.
- Previously, it defaulted to the Metal Tower.

Icon
- Added a custom application icon.

Floor / Boundary
- Floor tracking set to Floor for all of the scenes
- Positions can now be reset using the R key (as mentioned above).
- Added a startup check for headset status (called PrecheckScene):
  - If a headset is not detected, the application prompts the user to wear the headset and restart. The user must wear the headset BEFORE the Planica Experience is started (this is a common tracking bug with Meta Quest Link)
  - A quick restart can be done using the N key (it also now logs the exit event).

Interview Room
- Made video triggers more lenient (hidden bigger collision:
  - Users no longer need to be very close to start a video.
  - Introduced head tracking (instead of body tracking), enabling video playback when only the head enters the trigger area (same implementation like Tutorial scene).
