### PR TITLE
Fix overview scene label and label overflow

### DIFF
--- a/Assets/Prefabs/AirBalloon Simplified.prefab
+++ b/Assets/Prefabs/AirBalloon Simplified.prefab
@@ -6946,7 +6946,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5309647564991065821}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6954,8 +6954,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0, y: 186.4}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: -0, y: 183.3}
+  m_SizeDelta: {x: 220, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1174294594564183012
 CanvasRenderer:
@@ -7020,7 +7020,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Scenes/Immersive/OverviewScene.unity
+++ b/Assets/Scenes/Immersive/OverviewScene.unity
@@ -3994,24 +3994,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8300000, guid: 40b2ef38454482d49b4e28121bd61a33, type: 3}
     - target: {fileID: 4360984300616722958, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: locations.Array.data[0].additionalText
-      value: Fly around the metal tower located at the top of the ramp (highlighted).
-      objectReference: {fileID: 0}
-    - target: {fileID: 4360984300616722958, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: locations.Array.data[1].additionalText
       value: Explore the Arena on ground level and walk around (highlighted).
       objectReference: {fileID: 0}
     - target: {fileID: 4360984300616722958, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: locations.Array.data[3].additionalText
-      value: Fly around the round building located at the end of the ramp (highlighted).
-      objectReference: {fileID: 0}
-    - target: {fileID: 4360984300616722958, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: locations.Array.data[4].additionalText
       value: Explore the stage on ground level and walk around (highlighted).
-      objectReference: {fileID: 0}
-    - target: {fileID: 4360984300616722958, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
-      propertyPath: locations.Array.data[5].additionalText
-      value: Fly around the wooden building located at the top of the ramp (highlighted).
       objectReference: {fileID: 0}
     - target: {fileID: 5241269088104604742, guid: 4896814416a7f0a439c99da6c854955d, type: 3}
       propertyPath: m_CastShadows


### PR DESCRIPTION
We now have long titles that correctly overflow without covering the location images.

Also fixed the bug where the overview scene would use other labels because they override the prefab.